### PR TITLE
Update to 0.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.11.3
 
 # Mod Properties
-	mod_version = 0.2.1
+	mod_version = 0.3.0
 	maven_group = me.qtq
 	archives_base_name = BetterEatingMod
 

--- a/src/main/java/me/qtq/bettereating/BetterEatingConfig.java
+++ b/src/main/java/me/qtq/bettereating/BetterEatingConfig.java
@@ -12,4 +12,6 @@ public class BetterEatingConfig implements ConfigData {
     public boolean restrictPlaceBlocks = true;
 
     public boolean restrictUseBlocks = true;
+
+    public boolean restrictUseItems = true;
 }

--- a/src/main/java/me/qtq/bettereating/BetterEatingMod.java
+++ b/src/main/java/me/qtq/bettereating/BetterEatingMod.java
@@ -33,9 +33,13 @@ public class BetterEatingMod implements ModInitializer {
 	public static boolean blockUsageRestricted() {
 		return config.restrictUseBlocks;
 	}
+
+	public static boolean itemUsageRestricted() { return config.restrictUseItems;}
+
 	public static void startFoodTimer() {
 		foodTimerTicks = config.foodTimerLength;
 	}
+
 	public static void countDownFoodTimer() {
 		if (foodTimerTicks > 0) {
 			foodTimerTicks--;

--- a/src/main/java/me/qtq/bettereating/mixin/ClientPreventionMixin.java
+++ b/src/main/java/me/qtq/bettereating/mixin/ClientPreventionMixin.java
@@ -1,15 +1,14 @@
 package me.qtq.bettereating.mixin;
 
 import me.qtq.bettereating.BetterEatingMod;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.*;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.util.UseAction;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,6 +18,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ClientPlayerInteractionManager.class)
 public class ClientPreventionMixin {
+
+    // This method stops the player from placing a block if they are about to and the eating timer is active
     @Inject(at = @At("HEAD"), method = "interactBlock", cancellable = true)
     private void preventClientBlockUse(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockHitResult hitresult, CallbackInfoReturnable<ActionResult> Info) {
         if(!BetterEatingMod.foodTimerDone()) {
@@ -38,6 +39,18 @@ public class ClientPreventionMixin {
                 }
             }
             if(BetterEatingMod.blockPlacementRestricted() && useItemResult && itemIsBlock) {
+                Info.setReturnValue(ActionResult.PASS);
+            }
+        }
+    }
+    // This method stops the client from using non-food items while the eating timer is counting down
+    @Inject(at = @At("HEAD"), method = "interactItem", cancellable = true)
+    private void preventClientItemUse(PlayerEntity player, World world, Hand hand, CallbackInfoReturnable<ActionResult> Info) {
+        if(!BetterEatingMod.foodTimerDone()) {
+            ItemStack itemStack = player.getStackInHand(hand);
+
+            boolean itemIsFood = itemStack.isFood();
+            if(BetterEatingMod.itemUsageRestricted() && !itemIsFood) {
                 Info.setReturnValue(ActionResult.PASS);
             }
         }

--- a/src/main/resources/assets/bettereating/lang/en_us.json
+++ b/src/main/resources/assets/bettereating/lang/en_us.json
@@ -3,5 +3,6 @@
   "text.autoconfig.bettereating.option.foodTimerLength": "Post-Eating Delay Duration",
   "text.autoconfig.bettereating.option.foodTimerLength.@Tooltip": "Duration, in ticks, that you are prevented from doing other things",
   "text.autoconfig.bettereating.option.restrictPlaceBlocks": "Timer Restricts Block Placement",
-  "text.autoconfig.bettereating.option.restrictUseBlocks": "Timer Restricts Block Interactions"
+  "text.autoconfig.bettereating.option.restrictUseBlocks": "Timer Restricts Block Interactions",
+  "text.autoconfig.bettereating.option.restrictUseItems": "Timer Restricts Item Usage"
 }


### PR DESCRIPTION
Fixes an issue where non-food, non-block items were not prevented from being used immediately after eating (for instance, if you held an ender pearl in the off-hand, you would throw it immediately after eating food in the main hand)